### PR TITLE
Proposed Fix for .90

### DIFF
--- a/PartUtilities/JSIPartComponentGroup.cs
+++ b/PartUtilities/JSIPartComponentGroup.cs
@@ -81,6 +81,11 @@ namespace JSIPartUtilities
 		{
 			return currentState ? costOfBeingEnabled : 0;
 		}
+		
+		float IPartCostModifier.GetModuleCost(float defaultCost)
+		{
+			return currentState ? costOfBeingEnabled : 0;
+		}
 
 		#endregion
 

--- a/PartUtilities/JSIPartComponentToggle.cs
+++ b/PartUtilities/JSIPartComponentToggle.cs
@@ -88,6 +88,11 @@ namespace JSIPartUtilities
 			return currentState ? costOfBeingEnabled : 0;
 		}
 
+		float IPartCostModifier.GetModuleCost(float defaultCost)
+		{
+			return currentState ? costOfBeingEnabled : 0;
+		}
+
 		#endregion
 
 		public override void OnStart (PartModule.StartState state)


### PR DESCRIPTION
I fixed the two things that weren't compiling for .90... and now it's compiling for .90.  

I implemented IPartCostModifier.GetModuleCost(float defaultCost).   I just made it do the same thing as GetModuleCost () .  I didn't flip through the rest of the plugin to make sure this was the desired behavior... so I didn't delete the original GetModuleCost...  because it's best not to throw parts out of the car until you know what they do.  But it does compile and a quick test with the A.S.E.T rover shows that all the pieces of your plugin that mod uses are working... so that's promising.  I put a test binary up at 

https://www.dropbox.com/s/dhwtxhpaaw0mo1k/JSIPartUtilities.dll?dl=0  

and put that link in both your thread on the plugin, and the A.S.E.T rover's thread, so you might wait a day or two on a merge, in case someone reports bugs?
